### PR TITLE
BANG-899: Fix ast.arg lineno in complexity hook

### DIFF
--- a/hooks/utils/ast_helpers.py
+++ b/hooks/utils/ast_helpers.py
@@ -13,19 +13,19 @@ AnyFuncdef = Union[ast.FunctionDef, ast.AsyncFunctionDef]
 
 
 def get_ast_node_lineno(node: ast.AST) -> int:
-    if isinstance(node, (ast.expr, ast.stmt)):
+    if isinstance(node, (ast.expr, ast.stmt, ast.arg)):
         return node.lineno
     raise TypeError(f'AST node {type(node)!r} has no lineno')
 
 
 def get_ast_node_col_offset(node: ast.AST) -> int:
-    if isinstance(node, (ast.expr, ast.stmt)):
+    if isinstance(node, (ast.expr, ast.stmt, ast.arg)):
         return node.col_offset
     raise TypeError(f'AST node {type(node)!r} has no col_offset')
 
 
 def get_ast_node_end_col_offset(node: ast.AST) -> int | None:
-    if isinstance(node, (ast.expr, ast.stmt)):
+    if isinstance(node, (ast.expr, ast.stmt, ast.arg)):
         return node.end_col_offset
     return None
 

--- a/hooks/utils/tests/test_ast_helpers.py
+++ b/hooks/utils/tests/test_ast_helpers.py
@@ -7,6 +7,7 @@ import pytest
 from hooks.utils.ast_helpers import (
     _is_classdef_has_base_classes,
     get_assign_name,
+    get_ast_node_lineno,
     get_full_imported_name,
     get_var_names_from_assignment,
     get_var_names_from_funcdef,
@@ -41,6 +42,12 @@ def test_get_var_names_from_funcdef_success_case(def_str, variables_names):
     funcdef_node = ast.parse(def_str).body[0]
     actual_result = get_var_names_from_funcdef(funcdef_node)
     assert [r[0] for r in actual_result] == variables_names
+
+
+def test_get_ast_node_lineno__returns_lineno_for_function_argument():
+    function_argument = ast.parse('def foo(a): pass').body[0].args.args[0]
+
+    assert get_ast_node_lineno(function_argument) == 1
 
 
 @pytest.mark.parametrize(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pre-commit-hooks"
-version = "2.0.0"
+version = "2.0.1"
 description = "BestDoctor-wide pre-commit hooks."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Handle ast.arg in AST position helpers so validate_ajustable_complexity no longer crashes on Python 3.13+. Release 2.0.1.