### PR TITLE
BANG-899: Fix hooks for removed ast nodes in 3.14

### DIFF
--- a/hooks/validate_expressions_complexity.py
+++ b/hooks/validate_expressions_complexity.py
@@ -19,7 +19,6 @@ from hooks.utils.pre_commit import get_input_files
 _simple_types = [
     ast.Name,
     ast.Import,
-    ast.Bytes,
     ast.Nonlocal,
     ast.ImportFrom,
     ast.Pass,
@@ -27,16 +26,13 @@ _simple_types = [
     ast.Break,
     ast.Continue,
     type(None),
-    ast.Ellipsis,
 ]
 
-# Add deprecated types if they exist (Python < 3.12)
-if hasattr(ast, 'Str'):
-    _simple_types.append(ast.Str)
-if hasattr(ast, 'Num'):
-    _simple_types.append(ast.Num)
-if hasattr(ast, 'NameConstant'):
-    _simple_types.append(ast.NameConstant)
+# Add deprecated types if they exist (removed in Python 3.14)
+for _deprecated_type_name in ('Str', 'Num', 'Bytes', 'NameConstant', 'Ellipsis'):
+    _deprecated_type = getattr(ast, _deprecated_type_name, None)
+    if _deprecated_type is not None:
+        _simple_types.append(_deprecated_type)
 
 # Add ast.Constant for Python 3.8+ (replaces Str, Num, NameConstant)
 if hasattr(ast, 'Constant'):

--- a/hooks/validate_old_style_annotations.py
+++ b/hooks/validate_old_style_annotations.py
@@ -8,6 +8,15 @@ from hooks.utils.ast_helpers import get_ast_tree_with_content
 from hooks.utils.pre_commit import get_input_files
 
 
+def _is_old_style_string_annotation(node: ast.expr | None) -> bool:
+    if node is None:
+        return False
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return True
+    str_node_type = getattr(ast, 'Str', None)
+    return str_node_type is not None and isinstance(node, str_node_type)
+
+
 def main() -> Optional[int]:
     has_errors = False
     for pyfilepath in get_input_files():
@@ -19,7 +28,7 @@ def main() -> Optional[int]:
             [n.annotation for n in ast.walk(ast_tree) if isinstance(n, ast.arg) and n.annotation],
             [n.returns for n in ast.walk(ast_tree) if isinstance(n, ast.FunctionDef) and n.returns],
         ):
-            if isinstance(annotated, ast.Str):
+            if _is_old_style_string_annotation(annotated):
                 has_errors = True
                 print(  # noqa: T001
                     '{0}:{1} old style annotation'.format(pyfilepath, annotated.lineno)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pre-commit-hooks"
-version = "2.0.1"
+version = "2.0.2"
 description = "BestDoctor-wide pre-commit hooks."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Release 2.0.2: guard deprecated ast types with getattr and detect old-style string annotations via ast.Constant.